### PR TITLE
Add import(Rcpp) to NAMESPACE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,13 +4,14 @@ Title: Cox Proportional Hazards Regression for Right Truncated Data
 Version: 1.0.2
 Author: Bella Vakulenko-Lagun, Micha Mandel, Rebecca A. Betensky
 Maintainer: Bella Vakulenko-Lagun <bella.vakulenko-lagun@mail.huji.ac.il>
-Description: Fits Cox regression based on retrospectively ascertained times-to-event. The method uses Inverse-Probability-Weighting estimating equations. 
+Description: Fits Cox regression based on retrospectively ascertained times-to-event. The method uses Inverse-Probability-Weighting estimating equations.
 License: GPL (>= 2)
 Encoding: UTF-8
 LazyData: true
 Depends:
     R (>= 3.0.0)
-Imports: survival,
+Imports: Rcpp,
+          survival,
           BB,
           inline,
           gss,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 export(coxph.RT)
 export(coxph.RT.a0)
+import(Rcpp)
 import(BB)
 import(ggplot2)
 import(gss)


### PR DESCRIPTION
Should import Rcpp, or else the examples may fail. See here:
https://cloud.r-project.org/web/checks/check_results_coxrt.html

This error seems to occur for older versions of the Rcpp package. I don't get the error for the newest version, but it occurs for Rcpp 1.0.0.